### PR TITLE
修复CI测试：在无头环境中使用xvfb运行electron测试

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Server tests
         working-directory: server
-        run: pip install -r requirements.txt && python -m unittest discover -s . -p 'test_*.py' -v
+        run: pip install -r requirements.txt && python3 -m unittest discover -s . -p 'test_*.py' -v

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,12 @@ jobs:
         with:
           python-version: '3.11'
 
+      - name: Install xvfb
+        run: sudo apt-get update && sudo apt-get install -y xvfb
+
       - name: Client tests
         working-directory: client
-        run: npm ci && npm test
+        run: npm ci && xvfb-run --auto-servernum npm test
 
       - name: Server tests
         working-directory: server


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题描述

GitHub Actions CI测试失败，因为测试脚本试图在无头Ubuntu环境中直接运行electron，导致electron无法启动。

## 解决方案

在CI配置中添加xvfb（X Virtual Frame Buffer）支持，使electron可以在无头环境中运行：

1. 安装xvfb包
2. 使用`xvfb-run --auto-servernum`运行electron测试

## 测试

- 本地测试确认在安装依赖后，测试可以正常运行
- xvfb是在CI环境中运行electron应用的标准解决方案

## 修改文件

- `.github/workflows/ci.yml` - 添加xvfb安装步骤和使用xvfb-run运行测试
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9ca7-8426-7dd9-8f20-7e8a26b0fb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9ca7-8426-7dd9-8f20-7e8a26b0fb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

