### PR TITLE
修复测试：更新ORCHESTRATOR_SYSTEM断言以匹配最新代码

### DIFF
--- a/client/electron/__tests__/agent-delivery-policy.test.js
+++ b/client/electron/__tests__/agent-delivery-policy.test.js
@@ -57,8 +57,8 @@ test('orchestrator system includes delivery policy', () => {
 
 test('orchestrator prefers specialized assistants before CLI fallback', () => {
   const { ORCHESTRATOR_SYSTEM } = require('../mcp-manager');
-  assert.ok(ORCHESTRATOR_SYSTEM.includes('专业智能体'));
-  assert.ok(ORCHESTRATOR_SYSTEM.includes('assistant:'));
+  assert.ok(ORCHESTRATOR_SYSTEM.includes('社区智能体'));
+  assert.ok(ORCHESTRATOR_SYSTEM.includes('community:'));
   assert.ok(ORCHESTRATOR_SYSTEM.includes('必须') && ORCHESTRATOR_SYSTEM.includes('派发'));
   assert.ok(ORCHESTRATOR_SYSTEM.includes('不是默认执行者'));
   // 分析 / 派发 / 汇总 流水线
@@ -66,6 +66,6 @@ test('orchestrator prefers specialized assistants before CLI fallback', () => {
   assert.ok(ORCHESTRATOR_SYSTEM.includes('汇总'));
   // 异常兜底
   assert.ok(ORCHESTRATOR_SYSTEM.includes('异常兜底'));
-  assert.ok(ORCHESTRATOR_SYSTEM.includes('降级'));
+  assert.ok(ORCHESTRATOR_SYSTEM.includes('降级') || ORCHESTRATOR_SYSTEM.includes('自行'));
   assert.ok(ORCHESTRATOR_SYSTEM.includes('重试'));
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 问题描述

CI测试失败，错误信息：
```
assert.ok(ORCHESTRATOR_SYSTEM.includes('专业智能体'))
```

## 根本原因

提交 5bc158e 将代码中的用词从"专业智能体"改为"社区智能体"，从"assistant:"改为"community:"，但测试文件没有同步更新。

## 解决方案

更新测试断言以匹配最新的ORCHESTRATOR_SYSTEM实现：
- `'专业智能体'` → `'社区智能体'`
- `'assistant:'` → `'community:'`
- 调整降级检查：`'降级'` → `'降级' || '自行'`（因为新实现使用"自行完成"而不是"降级"）

## 测试结果

本地测试全部通过：
```
# tests 471
# pass 471
# fail 0
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019f9ca7-8426-7dd9-8f20-7e8a26b0fb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019f9ca7-8426-7dd9-8f20-7e8a26b0fb45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

