### PR TITLE
harden: fix security issue in server.py

### DIFF
--- a/server/server.py
+++ b/server/server.py
@@ -1079,10 +1079,25 @@ async def worker_ws(ws: WebSocket):
             [a.get("display_name") or a.get("id") for a in worker.agents],
         )
 
+        AUTH_RECHECK_INTERVAL = 300  # 秒：长连接定期复核 worker_key 是否仍有效/仍属该用户
+        last_auth_check = time.time()
         while True:
             raw = await ws.receive_text()
             msg = json.loads(raw)
             kind = msg.get("type")
+
+            # 已认证连接的持续授权复核：防止密钥被吊销/转移后，已建立的 WS 会话仍可无限期操作
+            now = time.time()
+            if now - last_auth_check > AUTH_RECHECK_INTERVAL:
+                current_user = await db.get_user_by_worker_key(worker_key)
+                if not current_user or current_user["id"] != user_id:
+                    logger.warning(
+                        "[worker/ws] deauthorized mid-session peer=%s worker_id=%s user_id=%s",
+                        peer, worker_id, user_id,
+                    )
+                    await ws.close(code=4001, reason="Unauthorized")
+                    return
+                last_auth_check = now
 
             # 武将任务进度：不摘 pending，供 HTTP SSE 转发
             if kind == "agent_task_progress":


### PR DESCRIPTION
## Summary
Harden input handling in `server/server.py` (flagged by multi_agent_ai).

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-005 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-005` |
| **File** | `server/server.py:1100` |
| **Assessment** | Defensive hardening |
| **Chain Complexity** | 2-step |

**Description**: The WebSocket endpoint /ws/worker validates the worker_key but does not implement additional authorization checks to ensure the registered worker is authorized to provide specific models or access certain resources. After initial authentication, there are no ongoing authorization checks for worker operations.

## Threat Model Context

This server appears to be publicly accessible.

## Changes
- `server/server.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path.

---
*This patch removes an exploit primitive — a code pattern that, while not independently exploitable today, could be chained with other weaknesses by automated exploit-development tooling. Proactive removal of such primitives raises the bar against increasingly capable automated attack tools.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*

<!-- orbis-meta: rule=V-005 scanner=multi_agent_ai -->
